### PR TITLE
remove 'padding' from ignored properties for inline elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ div {
 
 **Inline:**
 * Default value for elements. Think of elements like span, b or em
-* Will ignore top and bottom margin/padding settings, but will apply left and right margin/padding. Only moves horizontally, not vertically.
+* Will ignore top and bottom margin settings, but will apply left and right margin. Only moves horizontally, not vertically.
 * Is subject to vertical-align property.
 * Will ignore width and height properties.
 * If floated left or right, will automatically become a block-level element, subject to all block characteristics.


### PR DESCRIPTION
First of all, thanks for putting this together, it is one of the most succinct / easy to understand refreshers I've seen. 

I think the description for how an inline element responds to padding is inaccurate in that padding in all directions is respected. My suggested change simply removes 'padding' and keeps 'margin', since it correctly describes the fact that 'top' and 'bottom' margins are ignored while 'left' and 'right' are applied.

See http://codepen.io/bahrieinn/pen/KgxvrP for a working example. In the example, the `.inline-with-margin` element illustrates the `margin-top: 10px` style being ignored, while the `.inline-with-padding` element illustrates `padding-top: 10px` being applied. 
